### PR TITLE
Make the logo text clickable and redirect to main landing page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -83,7 +83,9 @@ function Dashboard({ user, setUser }) {
         <div className="landing-header-content">
           <div className="landing-logo">
             <FileText className="landing-logo-icon" />
-            <h1 className="landing-logo-text">Health Report Analyzer</h1>
+           <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+</Link>
             <button className="hamburger-btn" onClick={() => setMenuOpen(!menuOpen)}>
               {menuOpen ? <X size={24} /> : <Menu size={24} />}
             </button>
@@ -240,7 +242,9 @@ function App() {
                   <header className="app-header">
                     <div className="header-content">
                       <div className="header-text">
-                        <h1>🏥 Health Report Analyzer</h1>
+                         <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+</Link>
                         <p>
                           Secure platform to analyze your health reports with AI
                           insights
@@ -273,7 +277,9 @@ function App() {
                   <header className="app-header">
                     <div className="header-content">
                       <div className="header-text">
-                        <h1>🏥 Health Report Analyzer</h1>
+                          <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+</Link>
                         <p>
                           Secure platform to analyze your health reports with AI
                           insights
@@ -306,7 +312,9 @@ function App() {
                   <header className="app-header">
                     <div className="header-content">
                       <div className="header-text">
-                        <h1>🏥 Health Report Analyzer</h1>
+                          <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+</Link>
                         <p>Reset your password</p>
                       </div>
                       <div className="header-actions">
@@ -336,7 +344,9 @@ function App() {
                   <header className="app-header">
                     <div className="header-content">
                       <div className="header-text">
-                        <h1>🏥 Health Report Analyzer</h1>
+                           <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+</Link>
                         <p>Enter your new password</p>
                       </div>
                       <div className="header-actions">
@@ -364,7 +374,9 @@ function App() {
                   <header className="app-header">
                     <div className="header-content">
                       <div className="header-text">
-                        <h1>🏥 Health Report Analyzer</h1>
+                          <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+</Link>
                         <p>We'd love to hear from you!</p>
                       </div>
                       <div className="header-actions">

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -29,7 +29,9 @@ const Header = ({ user, setUser, isDashboard = false }) => {
       <div className="landing-header-content">
         <div className="landing-logo">
           <FileText className="landing-logo-icon" />
-          <h1 className="landing-logo-text">Health Report Analyzer</h1>
+         <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+  </Link>
         </div>
         
         {isDashboard ? (

--- a/client/src/components/LandingPage.jsx
+++ b/client/src/components/LandingPage.jsx
@@ -1,4 +1,5 @@
 // import React from 'react';
+import { Link } from 'react-router-dom';
 import React, { useState } from 'react';  // ⬅ add useState
 import { useNavigate } from 'react-router-dom';
 import { FileText, Shield, Zap, TrendingUp, Clock, LogOut } from 'lucide-react';
@@ -43,10 +44,12 @@ export default function LandingPage({ user, setUser }) {
       <header className="landing-header">
         <div className="landing-header-content">
           <div className="landing-logo">
-            <FileText className="landing-logo-icon" />
-            {/* <img src="/Health%20Report%20Analyzer%20Logo.png" alt="Logo" className="logo-img" /> */}
-            <h1 className="landing-logo-text">Health Report Analyzer</h1>
-          </div>
+  <FileText className="landing-logo-icon" />
+   {/* <img src="/Health%20Report%20Analyzer%20Logo.png" alt="Logo" className="logo-img" /> */}
+  <Link to="/" className="landing-logo-text">
+    Health Report Analyzer
+  </Link>
+</div>
           <div className="landing-header-buttons">
             {user ? (
               <>


### PR DESCRIPTION
This iPR addresses issue #112 

## PR Description
This PR ensures that the "Health Report Analyzer" logo is clickable and redirects users to the home page from all major pages, including:

- Landing page
- Dashboard header
- Login page
- Signup page

## Changes:

- Wrapped logo text (and icon where applicable) 
- Maintains existing styling and header layout
- Improves UX by allowing users to navigate home from any page

Tested locally to verify that clicking the logo redirects correctly.